### PR TITLE
릴리스노트 워크플로우 버그 수정

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -22,11 +22,19 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-action
 
+      - name: Set changelog path
+        id: changelog
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          # 패키지명 추출: @edge-effect/{package-name}@{version} → {package-name}
+          PACKAGE_NAME=$(echo "$TAG_NAME" | sed -E 's/@edge-effect\/([^@]+)@.*/\1/')
+          CHANGELOG_PATH="packages/${PACKAGE_NAME}/CHANGELOG.md"
+          echo "changelog_path=${CHANGELOG_PATH}" >> $GITHUB_OUTPUT
+
       - name: Generate Release Notes
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          files: |
-            packages/*/CHANGELOG.md
+          files: ${{ steps.changelog.outputs.changelog_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
lerna 태그 패턴을 기반으로 릴리스노트 워크플로우가 예상대로 동작되도록 수정 해야 합니다.